### PR TITLE
fix: update for Zig 0.12

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &.{"-std=c89"},
     });
-    lib.installHeader(.{ .path = "zconf.h" }, "zconf.h");
-    lib.installHeader(.{ .path = "zlib.h" }, "zlib.h");
+    lib.installHeader(b.path("zconf.h"), "zconf.h");
+    lib.installHeader(b.path("zlib.h"), "zlib.h");
     b.installArtifact(lib);
 }

--- a/build.zig
+++ b/build.zig
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &.{"-std=c89"},
     });
-    lib.installHeader("zconf.h", "zconf.h");
-    lib.installHeader("zlib.h", "zlib.h");
+    lib.installHeader(.{ .path = "zconf.h" }, "zconf.h");
+    lib.installHeader(.{ .path = "zlib.h" }, "zlib.h");
     b.installArtifact(lib);
 }

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const lib = b.addStaticLibrary(.{
         .name = "z",
         .target = b.standardTargetOptions(.{}),


### PR DESCRIPTION
I use your wrapper of `libz` for one of my little projects, and am trying to stay up to date with Zig master. Changed the argument in `build` to `std.Build` so it can be used with Zig 0.12.