### PR TITLE
update to zig 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /zig-cache
 /zig-out
+/.zig-cache

--- a/build.zig
+++ b/build.zig
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &.{"-std=c89"},
     });
-    lib.installHeader(.{ .path = "zconf.h" }, "zconf.h");
-    lib.installHeader(.{ .path = "zlib.h" }, "zlib.h");
+    lib.installHeader(b.path("zconf.h"), "zconf.h");
+    lib.installHeader(b.path("zlib.h"), "zlib.h");
     b.installArtifact(lib);
 }

--- a/build.zig
+++ b/build.zig
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &.{"-std=c89"},
     });
-    lib.installHeader("zconf.h", "zconf.h");
-    lib.installHeader("zlib.h", "zlib.h");
+    lib.installHeader(.{ .path = "zconf.h" }, "zconf.h");
+    lib.installHeader(.{ .path = "zlib.h" }, "zlib.h");
     b.installArtifact(lib);
 }

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const lib = b.addStaticLibrary(.{
         .name = "z",
         .target = b.standardTargetOptions(.{}),


### PR DESCRIPTION
Builds on PR #1, adds support for zig 0.13.0 by using `b.path`

- **fix: update for 0.12 builder**
- **fix: update for 0.12.0-dev.3667+77abd3a96**
- **update to zig 0.13.0**
