### PR TITLE
update to zig 0.15.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /zig-cache
 /zig-out
+/.zig-cache

--- a/build.zig
+++ b/build.zig
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &.{"-std=c89"},
     });
-    lib.installHeader(.{ .path = "zconf.h" }, "zconf.h");
-    lib.installHeader(.{ .path = "zlib.h" }, "zlib.h");
+    lib.installHeader(b.path("zconf.h"), "zconf.h");
+    lib.installHeader(b.path("zlib.h"), "zlib.h");
     b.installArtifact(lib);
 }

--- a/build.zig
+++ b/build.zig
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &.{"-std=c89"},
     });
-    lib.installHeader("zconf.h", "zconf.h");
-    lib.installHeader("zlib.h", "zlib.h");
+    lib.installHeader(.{ .path = "zconf.h" }, "zconf.h");
+    lib.installHeader(.{ .path = "zlib.h" }, "zlib.h");
     b.installArtifact(lib);
 }

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const lib = b.addStaticLibrary(.{
         .name = "z",
         .target = b.standardTargetOptions(.{}),

--- a/build.zig
+++ b/build.zig
@@ -1,10 +1,13 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "z",
-        .target = b.standardTargetOptions(.{}),
-        .optimize = b.standardOptimizeOption(.{}),
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = b.standardTargetOptions(.{}),
+            .optimize = b.standardOptimizeOption(.{}),
+        }),
     });
     lib.linkLibC();
     lib.addCSourceFiles(.{
@@ -27,7 +30,13 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &.{"-std=c89"},
     });
-    lib.installHeader(b.path("zconf.h"), "zconf.h");
-    lib.installHeader(b.path("zlib.h"), "zlib.h");
+    lib.installHeader(
+        b.path("zconf.h"),
+        "zconf.h",
+    );
+    lib.installHeader(
+        b.path("zlib.h"),
+        "zlib.h",
+    );
     b.installArtifact(lib);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "libz",
+    .name = .libz,
     .version = "1.3.0",
     .paths = .{
         "LICENSE",
@@ -33,4 +33,5 @@
         "zutil.c",
         "zutil.h",
     },
+    .fingerprint = 0xf0a9f60fb138e558,
 }


### PR DESCRIPTION
Builds on PR https://github.com/andrewrk/libz/pull/2
Adds support for Zig 0.15.1, +fingerprint

- fix: update for 0.12 builder
- fix: update for 0.12.0-dev.3667+77abd3a96
- update to zig 0.13.0
- update to zig 0.15.1